### PR TITLE
Updates Gradle Wrapper from 6.7 to 6.7.1

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -23,9 +23,9 @@ jobs:
           - 15
 
     steps:
-      - uses: actions/checkout@v2.3.2
+      - uses: actions/checkout@v2.3.4
       - name: Set up JDK
-        uses: actions/setup-java@v1.4.2
+        uses: actions/setup-java@v1.4.4
         with:
           java-version: ${{ matrix.java-version }}
 

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2.3.4
       - name: Set up JDK
-        uses: actions/setup-java@v1.4.4
+        uses: actions/setup-java@v1.4.3
         with:
           java-version: ${{ matrix.java-version }}
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=0080de8491f0918e4f529a6db6820fa0b9e818ee2386117f4394f95feb1d5583
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionSha256Sum=22449f5231796abd892c98b2a07c9ceebe4688d192cd2d6763f8e3bf8acbedeb
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Updates Gradle Wrapper from 6.7 to 6.7.1.

See release notes: https://docs.gradle.org/6.7.1/release-notes.html

---

🤖 This PR has been created by the [Update Gradle Wrapper](https://github.com/gradle-update/update-gradle-wrapper-action) action.

<details>
<summary>Need help? 🤔</summary>
<br />

If something doesn't look right with this PR please file an issue [here](https://github.com/gradle-update/update-gradle-wrapper-action/issues).
</details>